### PR TITLE
[Feat/#19] 로그인&회원가입 기능 추가(*일부 도메인 수정)

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -23,18 +23,25 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.0.3'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+	testImplementation 'junit:junit:4.13.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-//	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.hibernate:hibernate-spatial:6.4.1.Final'
 	implementation 'org.hibernate:hibernate-core:6.4.1.Final'
+
+	// Security + JWT
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/coumo/server/converter/CustomerConverter.java
+++ b/server/src/main/java/coumo/server/converter/CustomerConverter.java
@@ -20,11 +20,8 @@ public class CustomerConverter {
 
     public static CustomerResponseDTO.CustomerLoginResultDTO toCustomerLoginResultDTO(Customer customer, String token){
         return CustomerResponseDTO.CustomerLoginResultDTO.builder()
-                .id(customer.getId())
-                .loginId(customer.getLoginId())
-                .password(customer.getPassword())
+                .customerId(customer.getId())
                 .token(token)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
     public static Customer toCustomer(CustomerRequestDTO.CustomerJoinDTO request){

--- a/server/src/main/java/coumo/server/converter/CustomerConverter.java
+++ b/server/src/main/java/coumo/server/converter/CustomerConverter.java
@@ -22,6 +22,7 @@ public class CustomerConverter {
         return CustomerResponseDTO.CustomerLoginResultDTO.builder()
                 .id(customer.getId())
                 .loginId(customer.getLoginId())
+                .password(customer.getPassword())
                 .token(token)
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/server/src/main/java/coumo/server/converter/CustomerConverter.java
+++ b/server/src/main/java/coumo/server/converter/CustomerConverter.java
@@ -1,0 +1,43 @@
+package coumo.server.converter;
+
+import coumo.server.domain.Customer;
+import coumo.server.domain.enums.Gender;
+import coumo.server.web.dto.CustomerRequestDTO;
+import coumo.server.web.dto.CustomerResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class CustomerConverter {
+
+    public static CustomerResponseDTO.CustomerJoinResultDTO toJoinResultDTO(Customer customer){
+        return CustomerResponseDTO.CustomerJoinResultDTO.builder()
+                .id(customer.getId())
+                .loginId(customer.getLoginId())
+                .name(customer.getName())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static CustomerResponseDTO.CustomerLoginResultDTO toCustomerLoginResultDTO(Customer customer, String token){
+        return CustomerResponseDTO.CustomerLoginResultDTO.builder()
+                .id(customer.getId())
+                .loginId(customer.getLoginId())
+                .token(token)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+    public static Customer toCustomer(CustomerRequestDTO.CustomerJoinDTO request){
+
+        Gender gender = null;
+
+        return Customer.builder()
+                .loginId(request.getLoginId())
+                .password(request.getPassword())
+                .name(request.getName())
+                .birthday(request.getBirthday())
+                .gender(gender)
+                .email(request.getEmail())
+                .phone(request.getPhone())
+                .build();
+    }
+}

--- a/server/src/main/java/coumo/server/converter/OwnerConverter.java
+++ b/server/src/main/java/coumo/server/converter/OwnerConverter.java
@@ -19,11 +19,9 @@ public class OwnerConverter {
 
     public static OwnerResponseDTO.LoginResultDTO toLoginResultDTO(Owner owner, String token){
         return OwnerResponseDTO.LoginResultDTO.builder()
-                .id(owner.getId())
-                .loginId(owner.getLoginId())
-                .password(owner.getPassword())
+                .ownerId(owner.getId())
+                .storeId(owner.getStore().getId())
                 .token(token)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/server/src/main/java/coumo/server/converter/OwnerConverter.java
+++ b/server/src/main/java/coumo/server/converter/OwnerConverter.java
@@ -1,0 +1,39 @@
+package coumo.server.converter;
+
+import coumo.server.domain.Owner;
+import coumo.server.web.dto.OwnerRequestDTO;
+import coumo.server.web.dto.OwnerResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class OwnerConverter {
+
+    public static OwnerResponseDTO.JoinResultDTO toJoinResultDTO(Owner owner){
+        return OwnerResponseDTO.JoinResultDTO.builder()
+                .id(owner.getId())
+                .loginId(owner.getLoginId())
+                .name(owner.getName())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static OwnerResponseDTO.LoginResultDTO toLoginResultDTO(Owner owner, String token){
+        return OwnerResponseDTO.LoginResultDTO.builder()
+                .id(owner.getId())
+                .loginId(owner.getLoginId())
+                .password(owner.getPassword())
+                .token(token)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Owner toOwner(OwnerRequestDTO.JoinDTO request){
+        return Owner.builder()
+                .loginId(request.getLoginId())
+                .password(request.getPassword())
+                .name(request.getName())
+                .email(request.getEmail())
+                .phone(request.getPhone())
+                .build();
+    }
+}

--- a/server/src/main/java/coumo/server/domain/Customer.java
+++ b/server/src/main/java/coumo/server/domain/Customer.java
@@ -6,6 +6,8 @@ import coumo.server.domain.enums.State;
 import coumo.server.domain.mapping.CustomerStore;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +27,7 @@ public class Customer extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long loginId;
+    private String loginId;
 
     @Column(nullable = false, length = 64)
     private String name;
@@ -39,7 +41,7 @@ public class Customer extends BaseEntity {
     @Column(nullable = false, length = 64)
     private String email;
 
-    @Column(nullable = false, length = 32)
+    @Column(nullable = false, length = 64)
     private String password;
 
     @Enumerated(EnumType.STRING)
@@ -52,4 +54,8 @@ public class Customer extends BaseEntity {
 
     @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL)
     private List<CustomerStore> customerStoreList = new ArrayList<>();
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/server/src/main/java/coumo/server/domain/Owner.java
+++ b/server/src/main/java/coumo/server/domain/Owner.java
@@ -5,6 +5,8 @@ import coumo.server.domain.enums.State;
 import coumo.server.domain.enums.SubscriptionType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +27,7 @@ public class Owner extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long loginId;
+    private String loginId;
 
     @Column(nullable = false, length = 64)
     private String name;
@@ -36,7 +38,7 @@ public class Owner extends BaseEntity {
     @Column(nullable = false, length = 64)
     private String email;
 
-    @Column(nullable = false, length = 32)
+    @Column(nullable = false, length = 64)
     private String password;
 
     @Enumerated(EnumType.STRING)
@@ -58,5 +60,13 @@ public class Owner extends BaseEntity {
 
     public void setStore(Store store) {
         this.store = store;
+    }
+
+    public void setLoginId(String loginId) {
+        this.loginId = loginId;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 }

--- a/server/src/main/java/coumo/server/domain/enums/Gender.java
+++ b/server/src/main/java/coumo/server/domain/enums/Gender.java
@@ -1,5 +1,20 @@
 package coumo.server.domain.enums;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE("MALE"),
+    FEMALE("FEMALE");
+    private String value;
+
+    Gender(String value) {
+        this.value = value;
+    }
+
+    public static Gender fromString(String value) {
+        for (Gender gender : Gender.values()) {
+            if (gender.value.equalsIgnoreCase(value)) {
+                return gender;
+            }
+        }
+        return null; // or throw IllegalArgumentException
+    }
 }

--- a/server/src/main/java/coumo/server/jwt/AppJWTFilter.java
+++ b/server/src/main/java/coumo/server/jwt/AppJWTFilter.java
@@ -1,0 +1,72 @@
+package coumo.server.jwt;
+
+import coumo.server.domain.Customer;
+import coumo.server.web.dto.CustomCustomerDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class AppJWTFilter extends OncePerRequestFilter {
+    private final JWTUtil jwtUtil;
+
+    public AppJWTFilter(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        //request에서 Authorization 헤더를 찾음
+        String authorization = request.getHeader("Authorization");
+
+        //Authorication 헤더 검증
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료(필수)
+            return;
+        }
+
+        System.out.println("authorization now");
+        //Bearer 부분 제거 후 순수 토큰만 획득
+        String token = authorization.split(" ")[1];
+
+        //토큰 소멸 시간 검증
+        if (jwtUtil.isExpired(token)) {
+
+            System.out.println("token expired");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        //토큰에서 username 획득
+        String loginId = jwtUtil.getUsername(token);
+
+        //customer를 생성하여 값 set
+        Customer customer = Customer.builder()
+                .loginId(loginId)
+                .build();
+
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomCustomerDetails customCustomerDetails = new CustomCustomerDetails(customer);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customCustomerDetails, null, customCustomerDetails.getAuthorities());
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/server/src/main/java/coumo/server/jwt/AppLoginFilter.java
+++ b/server/src/main/java/coumo/server/jwt/AppLoginFilter.java
@@ -1,0 +1,76 @@
+package coumo.server.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import coumo.server.web.dto.CustomCustomerDetails;
+import coumo.server.web.dto.CustomOwnerDetails;
+import coumo.server.web.dto.CustomerRequestDTO;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+public class AppLoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+
+    //JWTUtil 주입
+    private final JWTUtil jwtUtil;
+
+    public AppLoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil){
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            //클라이언트 요청에서 loginId, password 추출
+            ObjectMapper objectMapper = new ObjectMapper();
+            CustomerRequestDTO.CustomerLoginDTO loginRequest = objectMapper.readValue(request.getInputStream(), CustomerRequestDTO.CustomerLoginDTO.class);
+
+            // 스프링 시큐리티에서 loginId와 password를 검증하기 위해서는 token에 담아야 함
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                    loginRequest.getLoginId(),
+                    loginRequest.getPassword()
+            );
+
+            // token에 담은 검증을 위한 AuthenticationManager로 전달
+            return authenticationManager.authenticate(authToken);
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading login request", e);
+        }
+    }
+    // 로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+        // 로그인 성공 로직 및 JWT 토큰 발급을 여기에 구현
+        // authentication.getName()을 통해 로그인한 사용자의 loginId을 가져올 수 있음.
+        // 발급된 토큰 response에 추가작업을 수행
+        CustomCustomerDetails customCustomerDetails = (CustomCustomerDetails) authentication.getPrincipal();
+        String loginId = customCustomerDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String token = jwtUtil.createJwt(loginId, 60*60*10L);
+
+        response.addHeader("Authorization", "Bearer " + token);
+    }
+
+    // 로그인 실패시 실행하는 메소드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        // 로그인 실패 로직을 여기에 구현
+        // 실패 원인 등을 확인 후 적절한 응답 생성
+        response.setStatus(401);
+    }
+}

--- a/server/src/main/java/coumo/server/jwt/JWTFilter.java
+++ b/server/src/main/java/coumo/server/jwt/JWTFilter.java
@@ -1,0 +1,74 @@
+package coumo.server.jwt;
+
+import coumo.server.domain.Customer;
+import coumo.server.domain.Owner;
+import coumo.server.service.owner.OwnerService;
+import coumo.server.web.dto.CustomOwnerDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    public JWTFilter(JWTUtil jwtUtil){
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        //request에서 Authorization 헤더를 찾음
+        String authorization = request.getHeader("Authorization");
+
+        //Authorication 헤더 검증
+        if(authorization == null || !authorization.startsWith("Bearer ")){
+
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료(필수)
+            return;
+        }
+
+        System.out.println("authorization now");
+        //Bearer 부분 제거 후 순수 토큰만 획득
+        String token = authorization.split(" ")[1];
+
+        //토큰 소멸 시간 검증
+        if (jwtUtil.isExpired(token)) {
+
+            System.out.println("token expired");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        //토큰에서 username 획득
+        String loginId = jwtUtil.getUsername(token);
+
+        //owner를 생성하여 값 set
+        Owner owner = Owner.builder()
+                .loginId(loginId)
+                .build();
+
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomOwnerDetails customOwnerDetails = new CustomOwnerDetails(owner);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOwnerDetails, null, customOwnerDetails.getAuthorities());
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/server/src/main/java/coumo/server/jwt/JWTUtil.java
+++ b/server/src/main/java/coumo/server/jwt/JWTUtil.java
@@ -1,0 +1,42 @@
+package coumo.server.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("loginId", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String loginId, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("loginId", loginId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/server/src/main/java/coumo/server/jwt/SecurityConfig.java
+++ b/server/src/main/java/coumo/server/jwt/SecurityConfig.java
@@ -1,0 +1,86 @@
+package coumo.server.jwt;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private static final String[] PERMIT_URL_ARRAY = {
+            /* swagger v2 */
+            "/v2/api-docs",
+            "/swagger-resources",
+            "/swagger-resources/**",
+            "/configuration/ui",
+            "/configuration/security",
+            "/swagger-ui.html",
+            "/webjars/**",
+            /* swagger v3 */
+            "/v3/api-docs/**",
+            "/swagger-ui/**"
+    };
+
+    //AuthenticationManager가 인자로 받을 AuthenticationConfiguraion 객체 생성자 주입
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    //JWTUtil 주입
+    private final JWTUtil jwtUtil;
+
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil) {
+
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtUtil = jwtUtil;
+
+    }
+
+    //AuthenticationManager Bean 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+
+        http.csrf((auth) -> auth.disable());
+
+        http.formLogin((auth) -> auth.disable());
+
+        http.httpBasic((auth) -> auth.disable());
+
+        http.authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/**", "/", "/join").permitAll()
+                        .requestMatchers(PERMIT_URL_ARRAY).permitAll()
+                        .anyRequest().authenticated());
+
+        //필터 추가 LoginFilter()는 인자를 받음 (AuthenticationManager() 메소드에 authenticationConfiguration 객체를 넣어야 함) 따라서 등록 필요
+        http.addFilterAt(new WebLoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class); //JWTUtil 인수 추가
+        http.addFilterAt(new AppLoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        //Owner의 JWTFilter 등록
+        http.addFilterBefore(new JWTFilter(jwtUtil), WebLoginFilter.class);
+        //Customer의 JWTFilter 등록
+        http.addFilterBefore(new AppJWTFilter(jwtUtil), AppLoginFilter.class);
+
+        http.sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/server/src/main/java/coumo/server/jwt/WebLoginFilter.java
+++ b/server/src/main/java/coumo/server/jwt/WebLoginFilter.java
@@ -1,0 +1,76 @@
+package coumo.server.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import coumo.server.web.dto.CustomOwnerDetails;
+import coumo.server.web.dto.OwnerRequestDTO;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+public class WebLoginFilter extends UsernamePasswordAuthenticationFilter{
+
+    private final AuthenticationManager authenticationManager;
+
+    //JWTUtil 주입
+    private final JWTUtil jwtUtil;
+
+    public WebLoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil){
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            //클라이언트 요청에서 loginId, password 추출
+            ObjectMapper objectMapper = new ObjectMapper();
+            OwnerRequestDTO.LoginDTO loginRequest = objectMapper.readValue(request.getInputStream(), OwnerRequestDTO.LoginDTO.class);
+
+            // 스프링 시큐리티에서 loginId와 password를 검증하기 위해서는 token에 담아야 함
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                    loginRequest.getLoginId(),
+                    loginRequest.getPassword()
+            );
+
+            // token에 담은 검증을 위한 AuthenticationManager로 전달
+            return authenticationManager.authenticate(authToken);
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading login request", e);
+        }
+    }
+    // 로그인 성공시 실행하는 메소드 (여기서 JWT를 발급하면 됨)
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+        // 로그인 성공 로직 및 JWT 토큰 발급을 여기에 구현
+        // authentication.getName()을 통해 로그인한 사용자의 loginId을 가져올 수 있음.
+        // 발급된 토큰 response에 추가작업을 수행
+        CustomOwnerDetails customOwnerDetails = (CustomOwnerDetails) authentication.getPrincipal();
+        String loginId = customOwnerDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String token = jwtUtil.createJwt(loginId, 60*60*10L);
+
+        response.addHeader("Authorization", "Bearer " + token);
+    }
+
+    // 로그인 실패시 실행하는 메소드
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        // 로그인 실패 로직을 여기에 구현
+        // 실패 원인 등을 확인 후 적절한 응답 생성
+        response.setStatus(401);
+    }
+}

--- a/server/src/main/java/coumo/server/repository/CustomerRepository.java
+++ b/server/src/main/java/coumo/server/repository/CustomerRepository.java
@@ -1,0 +1,9 @@
+package coumo.server.repository;
+
+import coumo.server.domain.Customer;
+import coumo.server.domain.Owner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+    Customer findByLoginId(String loginId);
+}

--- a/server/src/main/java/coumo/server/repository/OwnerRepository.java
+++ b/server/src/main/java/coumo/server/repository/OwnerRepository.java
@@ -9,6 +9,9 @@ import java.util.Optional;
 
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
 
+    Owner findByLoginId(String loginId);
+
     @Override
     Optional<Owner> findById(Long ownerId);
+
 }

--- a/server/src/main/java/coumo/server/service/customer/CustomCustomerDetailsService.java
+++ b/server/src/main/java/coumo/server/service/customer/CustomCustomerDetailsService.java
@@ -1,0 +1,32 @@
+package coumo.server.service.customer;
+
+import coumo.server.domain.Customer;
+import coumo.server.repository.CustomerRepository;
+import coumo.server.web.dto.CustomCustomerDetails;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomCustomerDetailsService implements UserDetailsService {
+
+    private final CustomerRepository customerRepository;
+
+    public CustomCustomerDetailsService(CustomerRepository customerRepository){
+        this.customerRepository = customerRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        //DB조회
+        Customer customerData = customerRepository.findByLoginId(loginId);
+
+        if(customerData != null){
+            //UserDetails에 담아서 return 하면 AuthenticationManager가 검증
+            return new CustomCustomerDetails(customerData);
+        }
+
+        throw new UsernameNotFoundException("User not found with loginId: " + loginId); //아이디 못찾은 경우
+    }
+}

--- a/server/src/main/java/coumo/server/service/customer/CustomerService.java
+++ b/server/src/main/java/coumo/server/service/customer/CustomerService.java
@@ -1,0 +1,15 @@
+package coumo.server.service.customer;
+
+import coumo.server.domain.Customer;
+import coumo.server.web.dto.CustomerRequestDTO;
+
+public interface CustomerService {
+
+    Customer findByLoginId(String loginId);
+
+    //회원가입
+    Customer joinCustomer(CustomerRequestDTO.CustomerJoinDTO request);
+
+    //로그인
+    Customer loginCustomer(CustomerRequestDTO.CustomerLoginDTO request);
+}

--- a/server/src/main/java/coumo/server/service/customer/CustomerServiceImpl.java
+++ b/server/src/main/java/coumo/server/service/customer/CustomerServiceImpl.java
@@ -1,60 +1,51 @@
-package coumo.server.service.owner;
+package coumo.server.service.customer;
 
-import coumo.server.converter.OwnerConverter;
+import coumo.server.converter.CustomerConverter;
+import coumo.server.domain.Customer;
 import coumo.server.domain.Owner;
-import coumo.server.repository.OwnerRepository;
+import coumo.server.repository.CustomerRepository;
+import coumo.server.web.dto.CustomerRequestDTO;
 import coumo.server.web.dto.OwnerRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class OwnerServiceImpl implements OwnerService{
+public class CustomerServiceImpl implements CustomerService{
 
-    private final OwnerRepository ownerRepository;
+    private final CustomerRepository customerRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
-    // Id로 사장님 찾기
     @Override
-    public Optional<Owner> findOwner(Long ownerId) {
-
-        return ownerRepository.findById(ownerId);
-    }
-
-    @Override
-    public Owner findByLoginId(String loginId) {
+    public Customer findByLoginId(String loginId) {
         //loginId기반으로 계정조회
-        return ownerRepository.findByLoginId(loginId);
+        return customerRepository.findByLoginId(loginId);
     }
 
-    // 회원가입 기능
     @Override
-    @Transactional
-    public Owner joinOwner(OwnerRequestDTO.JoinDTO request){
+    public Customer joinCustomer(CustomerRequestDTO.CustomerJoinDTO request){
 
-        Owner newOwner = OwnerConverter.toOwner(request);
+        Customer newCustomer = CustomerConverter.toCustomer(request);
         // 비밀번호를 BCrypt로 인코딩
-        newOwner.setPassword(passwordEncoder.encode(request.getPassword()));
-        return ownerRepository.save(newOwner);
+        newCustomer.setPassword(passwordEncoder.encode(request.getPassword()));
+        return customerRepository.save(newCustomer);
     }
 
     // 로그인 기능
     @Override
-    public Owner loginOwner(OwnerRequestDTO.LoginDTO request){
+    public Customer loginCustomer(CustomerRequestDTO.CustomerLoginDTO request){
         String loginId = request.getLoginId();
         String password = request.getPassword();
 
         // loginId로 계정 조회.
-        Owner owner = findByLoginId(loginId);
+        Customer customer = findByLoginId(loginId);
 
         // 소유자가 존재하고 비밀번호가 일치하는지 확인합니다.
-        if (owner != null && isPasswordMatch(password, owner.getPassword())) {
-            return owner; // 로그인 성공 시 소유자 엔터티를 반환합니다.
+        if (customer != null && isPasswordMatch(password, customer.getPassword())) {
+            return customer; // 로그인 성공 시 소유자 엔터티를 반환합니다.
         } else {
             return null; // 로그인 실패 시 null을 반환하거나 해당하는 방식으로 처리합니다.
         }
@@ -64,5 +55,6 @@ public class OwnerServiceImpl implements OwnerService{
         // BCryptPasswordEncoder를 사용하여 비밀번호 일치 여부 확인
         return passwordEncoder.matches(rawPassword, encodedPassword);
     }
+
 
 }

--- a/server/src/main/java/coumo/server/service/owner/CustomOwnerDetailsService.java
+++ b/server/src/main/java/coumo/server/service/owner/CustomOwnerDetailsService.java
@@ -1,0 +1,32 @@
+package coumo.server.service.owner;
+
+import coumo.server.domain.Owner;
+import coumo.server.repository.OwnerRepository;
+import coumo.server.web.dto.CustomOwnerDetails;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOwnerDetailsService implements UserDetailsService {
+
+    private final OwnerRepository ownerRepository;
+
+    public CustomOwnerDetailsService(OwnerRepository ownerRepository){
+        this.ownerRepository = ownerRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException{
+        //DB조회
+        Owner ownerData = ownerRepository.findByLoginId(loginId);
+
+        if(ownerData != null){
+            //UserDetails에 담아서 return 하면 AuthenticationManager가 검증
+            return new CustomOwnerDetails(ownerData);
+        }
+
+        throw new UsernameNotFoundException("User not found with loginId: " + loginId); //아이디 못찾은 경우
+    }
+}

--- a/server/src/main/java/coumo/server/service/owner/OwnerService.java
+++ b/server/src/main/java/coumo/server/service/owner/OwnerService.java
@@ -1,9 +1,18 @@
 package coumo.server.service.owner;
 
 import coumo.server.domain.Owner;
+import coumo.server.web.dto.OwnerRequestDTO;
 
 import java.util.Optional;
 
 public interface OwnerService {
     Optional<Owner> findOwner(Long ownerId);
+
+    Owner findByLoginId(String loginId);
+
+    // 회원가입
+    Owner joinOwner(OwnerRequestDTO.JoinDTO request);
+
+    //로그인
+    Owner loginOwner(OwnerRequestDTO.LoginDTO request);
 }

--- a/server/src/main/java/coumo/server/service/owner/OwnerServiceImpl.java
+++ b/server/src/main/java/coumo/server/service/owner/OwnerServiceImpl.java
@@ -3,6 +3,7 @@ package coumo.server.service.owner;
 import coumo.server.converter.OwnerConverter;
 import coumo.server.domain.Owner;
 import coumo.server.repository.OwnerRepository;
+import coumo.server.service.store.StoreCommandService;
 import coumo.server.web.dto.OwnerRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -18,6 +19,7 @@ public class OwnerServiceImpl implements OwnerService{
 
     private final OwnerRepository ownerRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final StoreCommandService storeCommandService;
 
     // Id로 사장님 찾기
     @Override
@@ -40,7 +42,9 @@ public class OwnerServiceImpl implements OwnerService{
         Owner newOwner = OwnerConverter.toOwner(request);
         // 비밀번호를 BCrypt로 인코딩
         newOwner.setPassword(passwordEncoder.encode(request.getPassword()));
-        return ownerRepository.save(newOwner);
+        Owner owner = ownerRepository.save(newOwner);
+        storeCommandService.createStore(owner.getId());
+        return owner;
     }
 
     // 로그인 기능

--- a/server/src/main/java/coumo/server/web/controller/CustomerRestController.java
+++ b/server/src/main/java/coumo/server/web/controller/CustomerRestController.java
@@ -1,0 +1,55 @@
+package coumo.server.web.controller;
+
+import coumo.server.apiPayload.ApiResponse;
+import coumo.server.converter.CustomerConverter;
+import coumo.server.converter.OwnerConverter;
+import coumo.server.domain.Customer;
+import coumo.server.domain.Owner;
+import coumo.server.jwt.JWTUtil;
+import coumo.server.service.customer.CustomerService;
+import coumo.server.web.dto.CustomerRequestDTO;
+import coumo.server.web.dto.CustomerResponseDTO;
+import coumo.server.web.dto.OwnerRequestDTO;
+import coumo.server.web.dto.OwnerResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/customer")
+public class CustomerRestController {
+
+    private final CustomerService customerService;
+    private final JWTUtil jwtUtil;
+
+    @PostMapping("/join")
+    @Operation(summary = "APP 회원가입 API",
+            description = "APP 회원가입 API 구현")
+    public ApiResponse<CustomerResponseDTO.CustomerJoinResultDTO> join(@RequestBody @Valid CustomerRequestDTO.CustomerJoinDTO request){
+        Customer customer = customerService.joinCustomer(request);
+        return ApiResponse.onSuccess(CustomerConverter.toJoinResultDTO(customer));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "APP 로그인 API",
+            description = "APP 로그인 API 구현")
+    public ApiResponse<CustomerResponseDTO.CustomerLoginResultDTO> login(@RequestBody @Valid CustomerRequestDTO.CustomerLoginDTO request){
+        Customer customer = customerService.loginCustomer(request);
+
+        if (customer != null) {
+            // 로그인 성공 시 토큰 생성
+            String token = jwtUtil.createJwt(request.getLoginId(), 3600000L); //토큰 만료 시간 1시간
+
+            // LoginResultDTO를 생성하여 반환
+            return ApiResponse.onSuccess(CustomerConverter.toCustomerLoginResultDTO(customer, token));
+        } else {
+            return ApiResponse.onFailure("400", "로그인에 실패했습니다.", null);
+        }
+
+    }
+}

--- a/server/src/main/java/coumo/server/web/controller/OwnerRestController.java
+++ b/server/src/main/java/coumo/server/web/controller/OwnerRestController.java
@@ -1,0 +1,52 @@
+package coumo.server.web.controller;
+
+import coumo.server.apiPayload.ApiResponse;
+import coumo.server.converter.OwnerConverter;
+import coumo.server.domain.Owner;
+import coumo.server.jwt.JWTUtil;
+import coumo.server.service.owner.OwnerService;
+import coumo.server.web.dto.OwnerRequestDTO;
+import coumo.server.web.dto.OwnerResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/owner")
+public class OwnerRestController {
+
+    private final OwnerService ownerService;
+    private final JWTUtil jwtUtil;
+
+    @PostMapping("/join")
+    @Operation(summary = "WEB 회원가입 API",
+            description = "WEB 회원가입 API 구현")
+    public ApiResponse<OwnerResponseDTO.JoinResultDTO> join(@RequestBody @Valid OwnerRequestDTO.JoinDTO request){
+        Owner owner = ownerService.joinOwner(request);
+        return ApiResponse.onSuccess(OwnerConverter.toJoinResultDTO(owner));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "WEB 로그인 API",
+            description = "WEB 로그인 API 구현")
+    public ApiResponse<OwnerResponseDTO.LoginResultDTO> login(@RequestBody @Valid OwnerRequestDTO.LoginDTO request){
+        Owner owner = ownerService.loginOwner(request);
+
+        if (owner != null) {
+            // 로그인 성공 시 토큰 생성
+            String token = jwtUtil.createJwt(request.getLoginId(), 3600000L); //토큰 만료 시간 1시간
+            
+            // LoginResultDTO를 생성하여 반환
+            return ApiResponse.onSuccess(OwnerConverter.toLoginResultDTO(owner, token));
+        } else {
+            return ApiResponse.onFailure("400", "로그인에 실패했습니다.", null);
+        }
+
+    }
+
+}

--- a/server/src/main/java/coumo/server/web/dto/CustomCustomerDetails.java
+++ b/server/src/main/java/coumo/server/web/dto/CustomCustomerDetails.java
@@ -1,0 +1,69 @@
+package coumo.server.web.dto;
+
+import coumo.server.domain.Customer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CustomCustomerDetails implements UserDetails{
+    private final Customer customer;
+
+    public CustomCustomerDetails(Customer customer){
+        this.customer = customer;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities(){
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return null;
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword(){
+
+        return customer.getPassword();
+    }
+
+    @Override
+    public String getUsername(){
+        return customer.getLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+}
+
+
+

--- a/server/src/main/java/coumo/server/web/dto/CustomOwnerDetails.java
+++ b/server/src/main/java/coumo/server/web/dto/CustomOwnerDetails.java
@@ -1,0 +1,67 @@
+package coumo.server.web.dto;
+
+import coumo.server.domain.Owner;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CustomOwnerDetails implements UserDetails {
+
+    private final Owner owner;
+
+    public CustomOwnerDetails(Owner owner){
+        this.owner = owner;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities(){
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return null;
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword(){
+
+        return owner.getPassword();
+    }
+
+    @Override
+    public String getUsername(){
+        return owner.getLoginId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+}

--- a/server/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
@@ -1,0 +1,23 @@
+package coumo.server.web.dto;
+
+import coumo.server.domain.enums.Gender;
+import lombok.Getter;
+
+public class CustomerRequestDTO {
+    @Getter
+    public static class CustomerJoinDTO {
+        String loginId;
+        String password;
+        String name;
+        String birthday;
+        Gender gender;
+        String email;
+        String phone;
+    }
+
+    @Getter
+    public static class CustomerLoginDTO{
+        String loginId;
+        String password;
+    }
+}

--- a/server/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
@@ -46,12 +46,8 @@ public class CustomerResponseDTO {
     @Getter
     @AllArgsConstructor
     public static class CustomerLoginResultDTO{
-        Long id;
-        String loginId;
-        String password;
+        Long customerId;
         private final String token;
-        LocalDateTime createdAt;
-
     }
 }
 

--- a/server/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
@@ -29,5 +29,29 @@ public class CustomerResponseDTO {
         this.createdAt=createdAt;
         this.updatedAt=updatedAt;
     }
+
+    // 회원가입
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CustomerJoinResultDTO {
+        long id;
+        String loginId;
+        String name;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class CustomerLoginResultDTO{
+        Long id;
+        String loginId;
+        String password;
+        private final String token;
+        LocalDateTime createdAt;
+
+    }
 }
 

--- a/server/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
@@ -1,0 +1,22 @@
+package coumo.server.web.dto;
+
+
+import lombok.Getter;
+
+public class OwnerRequestDTO {
+    /* 회원가입(Web) */
+    @Getter
+    public static class JoinDTO{
+        String loginId;
+        String password;
+        String name;
+        String email;
+        String phone;
+    }
+
+    @Getter
+    public static class LoginDTO{
+        String loginId;
+        String password;
+    }
+}

--- a/server/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
@@ -1,0 +1,33 @@
+package coumo.server.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class OwnerResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JoinResultDTO{
+        Long id;
+        String loginId;
+        String name;
+        LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class LoginResultDTO{
+        Long id;
+        String loginId;
+        String password;
+        private final String token;
+        LocalDateTime createdAt;
+
+    }
+}

--- a/server/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
+++ b/server/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
@@ -23,11 +23,8 @@ public class OwnerResponseDTO {
     @Getter
     @AllArgsConstructor
     public static class LoginResultDTO{
-        Long id;
-        String loginId;
-        String password;
+        Long ownerId;
+        Long storeId;
         private final String token;
-        LocalDateTime createdAt;
-
     }
 }


### PR DESCRIPTION
# 📄 Work Description
- APP&WEB 로그인&회원가입 기능 구현 완료
- JWT 적용하여 로그인 시 accessToken 발급받도록 추가 완료 
- 일부 코드의 수정사항 수정(아래의 To Reviewers 내용 확인 부탁드립니다!)

# ⚙️ ISSUE
- closed #19  


# 📷 Screenshot
- url 적용화면
<img width="907" alt="image" src="https://github.com/UMC-5th-Coumo/Coumo_Server/assets/150939763/47da6541-45ff-4fe6-8f47-10032cb410f9">

- WEB 회원가입
<img width="710" alt="image" src="https://github.com/UMC-5th-Coumo/Coumo_Server/assets/150939763/b69ecdf0-ee02-4660-b8a2-8673840dcd41">

- WEB 로그인
![image](https://github.com/UMC-5th-Coumo/Coumo_Server/assets/150939763/b4b07cb6-9c01-4b2f-b772-60f81121a367)

- APP 회원가입
<img width="711" alt="image" src="https://github.com/UMC-5th-Coumo/Coumo_Server/assets/150939763/e704aa6b-05f6-447a-a880-29e8e731759e">

- APP 로그인
![image](https://github.com/UMC-5th-Coumo/Coumo_Server/assets/150939763/1de09418-e3d5-4b8d-9533-1353e5b9d6ae)

# 💬 To Reviewers
- test과정에서 비밀번호 길이가 짧아 생기는 오류들이 많아 length = 64로 재조정 하였는데 확인부탁드립니다!
<img width="234" alt="image" src="https://github.com/UMC-5th-Coumo/Coumo_Server/assets/150939763/9c5aeadf-6b0e-4ccc-9f02-47f1e08e2671">

- Owner와 Customer 테이블의 loginId를 Long -> String 으로 수정하였습니다! (아마 중간에 잘못 수정되어 올라간 것 같습니다.)

- token값을 response에 띄우는 것은 성공했고, header에 적용하고 싶은데 방법을 잘 모르겠네요...아시는 분 카톡으로 알려주시면 감사하겠습니다!