### PR TITLE
[Feat/#56] : 아이디 중복확인 & 아이디 찾기(문자메세지 인증) & 내 프로필 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.0.3'
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 	testImplementation 'junit:junit:4.13.1'
@@ -42,6 +42,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// CoolSMS
+	implementation 'net.nurigo:sdk:4.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/coumo/server/converter/CustomerConverter.java
+++ b/src/main/java/coumo/server/converter/CustomerConverter.java
@@ -33,9 +33,18 @@ public class CustomerConverter {
                 .password(request.getPassword())
                 .name(request.getName())
                 .birthday(request.getBirthday())
-                .gender(gender)
+                .gender(request.getGender())
                 .email(request.getEmail())
                 .phone(request.getPhone())
                 .build();
+    }
+
+    public static CustomerResponseDTO.CustomerMyPageDTO toCustomerMyPageDTO(Customer customer) {
+        return new CustomerResponseDTO.CustomerMyPageDTO(
+                customer.getName(),
+                customer.getBirthday(),
+                customer.getGender().toString(),
+                customer.getPhone()
+        );
     }
 }

--- a/src/main/java/coumo/server/converter/OwnerConverter.java
+++ b/src/main/java/coumo/server/converter/OwnerConverter.java
@@ -34,4 +34,13 @@ public class OwnerConverter {
                 .phone(request.getPhone())
                 .build();
     }
+
+    public static OwnerResponseDTO.MyPageDTO toMyPageDTO(Owner owner){
+        return OwnerResponseDTO.MyPageDTO.builder()
+                .name(owner.getName())
+                .loginId(owner.getLoginId())
+                .email(owner.getEmail())
+                .phone(owner.getPhone())
+                .build();
+    }
 }

--- a/src/main/java/coumo/server/repository/CustomerRepository.java
+++ b/src/main/java/coumo/server/repository/CustomerRepository.java
@@ -6,4 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Customer findByLoginId(String loginId);
+
+    //로그인 중복확인
+    boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/coumo/server/repository/CustomerRepository.java
+++ b/src/main/java/coumo/server/repository/CustomerRepository.java
@@ -2,11 +2,22 @@ package coumo.server.repository;
 
 import coumo.server.domain.Customer;
 import coumo.server.domain.Owner;
+import coumo.server.web.dto.LoginIdDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
     Customer findByLoginId(String loginId);
 
     //로그인 중복확인
     boolean existsByLoginId(String loginId);
+
+    Optional<Customer> findByNameAndPhone(String name, String phone);
+
+    // JPQL 쿼리를 사용하여 loginId 필드만 조회
+    @Query("SELECT new coumo.server.web.dto.LoginIdDTO(c.loginId) FROM Customer c WHERE c.phone = :phone")
+    Optional<LoginIdDTO> findLoginIdByPhone(@Param("phone") String phone);
 }

--- a/src/main/java/coumo/server/repository/OwnerRepository.java
+++ b/src/main/java/coumo/server/repository/OwnerRepository.java
@@ -14,4 +14,6 @@ public interface OwnerRepository extends JpaRepository<Owner, Long> {
     @Override
     Optional<Owner> findById(Long ownerId);
 
+    //로그인 중복확인
+    boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/coumo/server/repository/OwnerRepository.java
+++ b/src/main/java/coumo/server/repository/OwnerRepository.java
@@ -1,9 +1,13 @@
 package coumo.server.repository;
 
 
+import coumo.server.domain.Customer;
 import coumo.server.domain.Owner;
 import coumo.server.domain.Store;
+import coumo.server.web.dto.LoginIdDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -16,4 +20,10 @@ public interface OwnerRepository extends JpaRepository<Owner, Long> {
 
     //로그인 중복확인
     boolean existsByLoginId(String loginId);
+
+    Optional<Owner> findByNameAndPhone(String name, String phone);
+
+    // JPQL 쿼리를 사용하여 loginId 필드만 조회
+    @Query("SELECT new coumo.server.web.dto.LoginIdDTO(c.loginId) FROM Owner c WHERE c.phone = :phone")
+    Optional<LoginIdDTO> findLoginIdByPhone(@Param("phone") String phone);
 }

--- a/src/main/java/coumo/server/service/customer/CustomerService.java
+++ b/src/main/java/coumo/server/service/customer/CustomerService.java
@@ -2,8 +2,13 @@ package coumo.server.service.customer;
 
 import coumo.server.domain.Customer;
 import coumo.server.web.dto.CustomerRequestDTO;
+import coumo.server.web.dto.LoginIdDTO;
+
+import java.util.Optional;
 
 public interface CustomerService {
+
+    Optional<Customer> findCustomerById(Long customerId);
 
     Customer findByLoginId(String loginId);
 
@@ -15,4 +20,10 @@ public interface CustomerService {
 
     //로그인 중복확인
     boolean isLoginIdAvailable(String loginId);
+
+    //인증번호
+    Optional<Customer> findCustomerByNameAndPhone(String name, String phone);
+
+    //인증번호 검증
+    Optional<LoginIdDTO> findLoginIdByPhone(String phone);
 }

--- a/src/main/java/coumo/server/service/customer/CustomerService.java
+++ b/src/main/java/coumo/server/service/customer/CustomerService.java
@@ -12,4 +12,7 @@ public interface CustomerService {
 
     //로그인
     Customer loginCustomer(CustomerRequestDTO.CustomerLoginDTO request);
+
+    //로그인 중복확인
+    boolean isLoginIdAvailable(String loginId);
 }

--- a/src/main/java/coumo/server/service/customer/CustomerServiceImpl.java
+++ b/src/main/java/coumo/server/service/customer/CustomerServiceImpl.java
@@ -56,5 +56,10 @@ public class CustomerServiceImpl implements CustomerService{
         return passwordEncoder.matches(rawPassword, encodedPassword);
     }
 
-
+    // 로그인ID 중복확인
+    @Override
+    public boolean isLoginIdAvailable(String loginId){
+        // 해당 로그인 ID가 데이터베이스에 존재하는지 확인
+        return !customerRepository.existsByLoginId(loginId);
+    }
 }

--- a/src/main/java/coumo/server/service/customer/CustomerServiceImpl.java
+++ b/src/main/java/coumo/server/service/customer/CustomerServiceImpl.java
@@ -5,11 +5,14 @@ import coumo.server.domain.Customer;
 import coumo.server.domain.Owner;
 import coumo.server.repository.CustomerRepository;
 import coumo.server.web.dto.CustomerRequestDTO;
+import coumo.server.web.dto.LoginIdDTO;
 import coumo.server.web.dto.OwnerRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +21,11 @@ public class CustomerServiceImpl implements CustomerService{
 
     private final CustomerRepository customerRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+
+    @Override
+    public Optional<Customer> findCustomerById(Long customerId) {
+        return customerRepository.findById(customerId);
+    }
 
     @Override
     public Customer findByLoginId(String loginId) {
@@ -61,5 +69,17 @@ public class CustomerServiceImpl implements CustomerService{
     public boolean isLoginIdAvailable(String loginId){
         // 해당 로그인 ID가 데이터베이스에 존재하는지 확인
         return !customerRepository.existsByLoginId(loginId);
+    }
+
+    //인증번호
+    @Override
+    public Optional<Customer> findCustomerByNameAndPhone(String name, String phone) {
+        return customerRepository.findByNameAndPhone(name, phone);
+    }
+
+    //인증번호 검증
+    @Override
+    public Optional<LoginIdDTO> findLoginIdByPhone(String phone){
+        return customerRepository.findLoginIdByPhone(phone);
     }
 }

--- a/src/main/java/coumo/server/service/owner/OwnerService.java
+++ b/src/main/java/coumo/server/service/owner/OwnerService.java
@@ -15,4 +15,7 @@ public interface OwnerService {
 
     //로그인
     Owner loginOwner(OwnerRequestDTO.LoginDTO request);
+
+    //로그인 중복확인
+    boolean isLoginIdAvailable(String loginId);
 }

--- a/src/main/java/coumo/server/service/owner/OwnerService.java
+++ b/src/main/java/coumo/server/service/owner/OwnerService.java
@@ -1,6 +1,8 @@
 package coumo.server.service.owner;
 
+import coumo.server.domain.Customer;
 import coumo.server.domain.Owner;
+import coumo.server.web.dto.LoginIdDTO;
 import coumo.server.web.dto.OwnerRequestDTO;
 
 import java.util.Optional;
@@ -18,4 +20,10 @@ public interface OwnerService {
 
     //로그인 중복확인
     boolean isLoginIdAvailable(String loginId);
+
+    //인증번호
+    Optional<Owner> findOwnerByNameAndPhone(String name, String phone);
+
+    //인증번호 검증
+    Optional<LoginIdDTO> findLoginIdByPhone(String phone);
 }

--- a/src/main/java/coumo/server/service/owner/OwnerServiceImpl.java
+++ b/src/main/java/coumo/server/service/owner/OwnerServiceImpl.java
@@ -1,9 +1,11 @@
 package coumo.server.service.owner;
 
 import coumo.server.converter.OwnerConverter;
+import coumo.server.domain.Customer;
 import coumo.server.domain.Owner;
 import coumo.server.repository.OwnerRepository;
 import coumo.server.service.store.StoreCommandService;
+import coumo.server.web.dto.LoginIdDTO;
 import coumo.server.web.dto.OwnerRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -74,5 +76,17 @@ public class OwnerServiceImpl implements OwnerService{
     public boolean isLoginIdAvailable(String loginId){
         // 해당 로그인 ID가 데이터베이스에 존재하는지 확인
         return !ownerRepository.existsByLoginId(loginId);
+    }
+
+    //인증번호
+    @Override
+    public Optional<Owner> findOwnerByNameAndPhone(String name, String phone) {
+        return ownerRepository.findByNameAndPhone(name, phone);
+    }
+
+    //인증번호 검증
+    @Override
+    public Optional<LoginIdDTO> findLoginIdByPhone(String phone){
+        return ownerRepository.findLoginIdByPhone(phone);
     }
 }

--- a/src/main/java/coumo/server/service/owner/OwnerServiceImpl.java
+++ b/src/main/java/coumo/server/service/owner/OwnerServiceImpl.java
@@ -69,4 +69,10 @@ public class OwnerServiceImpl implements OwnerService{
         return passwordEncoder.matches(rawPassword, encodedPassword);
     }
 
+    // 로그인ID 중복확인
+    @Override
+    public boolean isLoginIdAvailable(String loginId){
+        // 해당 로그인 ID가 데이터베이스에 존재하는지 확인
+        return !ownerRepository.existsByLoginId(loginId);
+    }
 }

--- a/src/main/java/coumo/server/sms/MessageService.java
+++ b/src/main/java/coumo/server/sms/MessageService.java
@@ -34,7 +34,7 @@ public class MessageService {
         Message message = new Message();
         message.setFrom(fromNumber); // 발신번호 설정
         message.setTo(toNumber); // 수신번호 설정
-        message.setText("[Coumo] 아래의 인증번호를 입력하세요'\n" + verificationCode); // 메시지 내용 설정
+        message.setText("[Coumo] 아래의 인증번호를 입력하세요\n" + verificationCode); // 메시지 내용 설정
 
         try {
             SingleMessageSentResponse response = messageService.sendOne(new SingleMessageSendingRequest(message));

--- a/src/main/java/coumo/server/sms/MessageService.java
+++ b/src/main/java/coumo/server/sms/MessageService.java
@@ -1,0 +1,54 @@
+package coumo.server.sms;
+
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+
+@Service
+public class MessageService {
+
+    private final DefaultMessageService messageService;
+    private final VerificationCodeStorage verificationCodeStorage;
+
+    @Value("${coolsms.from.number}")
+    private String fromNumber;
+
+    @Autowired
+    public MessageService(@Value("${coolsms.api.key}") String apiKey,
+                          @Value("${coolsms.api.secret}") String apiSecret,
+                          VerificationCodeStorage verificationCodeStorage) {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+        this.verificationCodeStorage = verificationCodeStorage;
+    }
+
+    public void sendMessage(String toNumber) {
+        String verificationCode = generateRandomNumber();
+        Message message = new Message();
+        message.setFrom(fromNumber); // 발신번호 설정
+        message.setTo(toNumber); // 수신번호 설정
+        message.setText("[Coumo] 아래의 인증번호를 입력하세요'\n" + verificationCode); // 메시지 내용 설정
+
+        try {
+            SingleMessageSentResponse response = messageService.sendOne(new SingleMessageSendingRequest(message));
+            System.out.println("Message sent successfully: " + response.getMessageId());
+            //인증번호 저장
+            verificationCodeStorage.saveCode(toNumber, verificationCode);
+        } catch (Exception e) {
+            e.printStackTrace(); // 예외 처리
+        }
+    }
+
+    private String generateRandomNumber() {
+        Random rnd = new Random();
+        int number = rnd.nextInt(999999);
+        return String.format("%06d", number); // 6자리 인증번호 생성
+    }
+}

--- a/src/main/java/coumo/server/sms/VerificationCodeStorage.java
+++ b/src/main/java/coumo/server/sms/VerificationCodeStorage.java
@@ -1,0 +1,19 @@
+package coumo.server.sms;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class VerificationCodeStorage {
+    private final ConcurrentHashMap<String, String> verificationCodes = new ConcurrentHashMap<>();
+
+    public void saveCode(String phone, String code) {
+        verificationCodes.put(phone, code);
+    }
+
+    public boolean verifyCode(String phone, String code) {
+        String savedCode = verificationCodes.get(phone);
+        return savedCode != null && savedCode.equals(code);
+    }
+}

--- a/src/main/java/coumo/server/web/controller/CustomerRestController.java
+++ b/src/main/java/coumo/server/web/controller/CustomerRestController.java
@@ -2,22 +2,22 @@ package coumo.server.web.controller;
 
 import coumo.server.apiPayload.ApiResponse;
 import coumo.server.converter.CustomerConverter;
-import coumo.server.converter.OwnerConverter;
 import coumo.server.domain.Customer;
-import coumo.server.domain.Owner;
 import coumo.server.jwt.JWTUtil;
 import coumo.server.service.customer.CustomerService;
+import coumo.server.sms.MessageService;
+import coumo.server.sms.VerificationCodeStorage;
 import coumo.server.web.dto.CustomerRequestDTO;
 import coumo.server.web.dto.CustomerResponseDTO;
-import coumo.server.web.dto.OwnerRequestDTO;
-import coumo.server.web.dto.OwnerResponseDTO;
+import coumo.server.web.dto.LoginIdDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,6 +26,8 @@ public class CustomerRestController {
 
     private final CustomerService customerService;
     private final JWTUtil jwtUtil;
+    private final MessageService messageService;
+    private final VerificationCodeStorage verificationCodeStorage;
 
     @PostMapping("/join")
     @Operation(summary = "APP 회원가입 API",
@@ -66,6 +68,49 @@ public class CustomerRestController {
         } else {
             // 로그인 ID가 이미 사용 중인 경우
             return ApiResponse.onFailure("400", "이미 사용 중인 로그인 ID입니다.", null);
+        }
+    }
+
+    @GetMapping("/mypage/{customerId}/profile")
+    @Operation(summary = "마이페이지 내 프로필 조회 API", description = "로그인한 사용자의 마이페이지 프로필을 조회합니다.")
+    @Parameters({
+            @Parameter(name = "customerId", description = "customerId, path variable 입니다!"),
+    })
+    public ApiResponse<CustomerResponseDTO.CustomerMyPageDTO> getCustomerMyPage(@PathVariable Long customerId){
+        Optional<Customer> customerOpt = customerService.findCustomerById(customerId);
+        if (customerOpt.isPresent()) {
+            Customer customer = customerOpt.get();
+            CustomerResponseDTO.CustomerMyPageDTO customerMyPageDTO = CustomerConverter.toCustomerMyPageDTO(customer);
+            return ApiResponse.onSuccess(customerMyPageDTO);
+        } else {
+            return ApiResponse.onFailure("404", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+    }
+
+    @PostMapping("/find-id")
+    @Operation(summary = "[아이디찾기] 인증번호 전송 API", description = "인증번호가 전송되었는지 확인합니다.")
+    public ApiResponse<String> sendVerificationCode(@RequestBody CustomerRequestDTO.VerificationRequest request) {
+        Optional<Customer> customerOpt = customerService.findCustomerByNameAndPhone(request.getName(), request.getPhone());
+        if (customerOpt.isPresent()) {
+            messageService.sendMessage(request.getPhone());
+            return ApiResponse.onSuccess("인증번호가 전송되었습니다.");
+        } else {
+            return ApiResponse.onFailure("404", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+    }
+
+    @PostMapping("/verify-code")
+    @Operation(summary = "[아이디찾기] 인증번호 검증 및 로그인 ID 반환 API", description = "인증번호가 일치하는지 확인하고 loginId를 반환합니다.")
+    public ApiResponse<String> verifyCode(@RequestBody CustomerRequestDTO.VerificationCodeDTO dto) {
+        boolean isVerified = verificationCodeStorage.verifyCode(dto.getPhone(), dto.getVerificationCode());
+
+         if (isVerified) {
+             String loginId = customerService.findLoginIdByPhone(dto.getPhone())
+                     .map(LoginIdDTO::getLoginId) // LoginIdDTO 객체에서 loginId필드값 추출
+                     .orElse("로그인 ID를 찾을 수 없습니다.");
+            return ApiResponse.onSuccess(loginId);
+        } else {
+            return ApiResponse.onFailure("400", "인증번호가 일치하지 않습니다.", null);
         }
     }
 }

--- a/src/main/java/coumo/server/web/controller/CustomerRestController.java
+++ b/src/main/java/coumo/server/web/controller/CustomerRestController.java
@@ -72,7 +72,7 @@ public class CustomerRestController {
     }
 
     @GetMapping("/mypage/{customerId}/profile")
-    @Operation(summary = "마이페이지 내 프로필 조회 API", description = "로그인한 사용자의 마이페이지 프로필을 조회합니다.")
+    @Operation(summary = "APP 마이페이지 내 프로필 조회 API", description = "로그인한 사용자의 마이페이지 프로필을 조회합니다.")
     @Parameters({
             @Parameter(name = "customerId", description = "customerId, path variable 입니다!"),
     })
@@ -88,7 +88,7 @@ public class CustomerRestController {
     }
 
     @PostMapping("/find-id")
-    @Operation(summary = "[아이디찾기] 인증번호 전송 API", description = "인증번호가 전송되었는지 확인합니다.")
+    @Operation(summary = "[아이디찾기] APP 인증번호 전송 API", description = "인증번호가 전송되었는지 확인합니다.")
     public ApiResponse<String> sendVerificationCode(@RequestBody CustomerRequestDTO.VerificationRequest request) {
         Optional<Customer> customerOpt = customerService.findCustomerByNameAndPhone(request.getName(), request.getPhone());
         if (customerOpt.isPresent()) {
@@ -100,7 +100,7 @@ public class CustomerRestController {
     }
 
     @PostMapping("/verify-code")
-    @Operation(summary = "[아이디찾기] 인증번호 검증 및 로그인 ID 반환 API", description = "인증번호가 일치하는지 확인하고 loginId를 반환합니다.")
+    @Operation(summary = "[아이디찾기] APP 인증번호 검증 및 로그인 ID 반환 API", description = "인증번호가 일치하는지 확인하고 loginId를 반환합니다.")
     public ApiResponse<String> verifyCode(@RequestBody CustomerRequestDTO.VerificationCodeDTO dto) {
         boolean isVerified = verificationCodeStorage.verifyCode(dto.getPhone(), dto.getVerificationCode());
 

--- a/src/main/java/coumo/server/web/controller/CustomerRestController.java
+++ b/src/main/java/coumo/server/web/controller/CustomerRestController.java
@@ -50,6 +50,22 @@ public class CustomerRestController {
         } else {
             return ApiResponse.onFailure("400", "로그인에 실패했습니다.", null);
         }
+    }
 
+    @PostMapping("/join/check-login-id")
+    @Operation(summary = "APP 로그인 ID 중복 확인 API",
+            description = "APP 로그인 ID 중복 확인 API 구현")
+    public ApiResponse<CustomerResponseDTO.CheckCustomerLoginIdResponseDTO> checkCustomerLoginId(@RequestBody @Valid CustomerRequestDTO.CheckCustomerLoginIdDTO request){
+        boolean isLoginIdAvailable = customerService.isLoginIdAvailable(request.getLoginId());
+
+        if(isLoginIdAvailable){
+            // 로그인 ID가 사용 가능할 경우
+            return ApiResponse.onSuccess(CustomerResponseDTO.CheckCustomerLoginIdResponseDTO.builder()
+                    .loginId(request.getLoginId())
+                    .build());
+        } else {
+            // 로그인 ID가 이미 사용 중인 경우
+            return ApiResponse.onFailure("400", "이미 사용 중인 로그인 ID입니다.", null);
+        }
     }
 }

--- a/src/main/java/coumo/server/web/controller/OwnerRestController.java
+++ b/src/main/java/coumo/server/web/controller/OwnerRestController.java
@@ -2,9 +2,14 @@ package coumo.server.web.controller;
 
 import coumo.server.apiPayload.ApiResponse;
 import coumo.server.converter.OwnerConverter;
+import coumo.server.domain.Customer;
 import coumo.server.domain.Owner;
 import coumo.server.jwt.JWTUtil;
 import coumo.server.service.owner.OwnerService;
+import coumo.server.sms.MessageService;
+import coumo.server.sms.VerificationCodeStorage;
+import coumo.server.web.dto.CustomerRequestDTO;
+import coumo.server.web.dto.LoginIdDTO;
 import coumo.server.web.dto.OwnerRequestDTO;
 import coumo.server.web.dto.OwnerResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +19,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Optional;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/owner")
@@ -21,6 +28,8 @@ public class OwnerRestController {
 
     private final OwnerService ownerService;
     private final JWTUtil jwtUtil;
+    private final MessageService messageService;
+    private final VerificationCodeStorage verificationCodeStorage;
 
     @PostMapping("/join")
     @Operation(summary = "WEB 회원가입 API",
@@ -66,7 +75,7 @@ public class OwnerRestController {
     }
 
     @GetMapping("/mypage/{ownerId}/profile")
-    @Operation(summary = "마이페이지 내 프로필 조회 API", description = "로그인한 사장님의 마이페이지 프로필을 조회합니다.")
+    @Operation(summary = "WEB 마이페이지 내 프로필 조회 API", description = "로그인한 사장님의 마이페이지 프로필을 조회합니다.")
     @Parameters({
             @Parameter(name = "ownerId", description = "ownerId, path variable 입니다!"),
     })
@@ -74,5 +83,32 @@ public class OwnerRestController {
         return ownerService.findOwner(ownerId)
                 .map(owner -> ApiResponse.onSuccess(OwnerConverter.toMyPageDTO(owner)))
                 .orElse(ApiResponse.onFailure("400", "사용자 정보를 찾을 수 없습니다.", null));
+    }
+
+    @PostMapping("/find-id")
+    @Operation(summary = "[아이디찾기] WEB 인증번호 전송 API", description = "인증번호가 전송되었는지 확인합니다.")
+    public ApiResponse<String> sendVerificationCode(@RequestBody OwnerRequestDTO.OwnerVerificationRequest request) {
+        Optional<Owner> ownerOpt = ownerService.findOwnerByNameAndPhone(request.getName(), request.getPhone());
+        if (ownerOpt.isPresent()) {
+            messageService.sendMessage(request.getPhone());
+            return ApiResponse.onSuccess("인증번호가 전송되었습니다.");
+        } else {
+            return ApiResponse.onFailure("404", "사용자 정보를 찾을 수 없습니다.", null);
+        }
+    }
+
+    @PostMapping("/verify-code")
+    @Operation(summary = "[아이디찾기] WEB 인증번호 검증 및 로그인 ID 반환 API", description = "인증번호가 일치하는지 확인하고 loginId를 반환합니다.")
+    public ApiResponse<String> verifyCode(@RequestBody OwnerRequestDTO.OwnerVerificationCodeDTO dto) {
+        boolean isVerified = verificationCodeStorage.verifyCode(dto.getPhone(), dto.getVerificationCode());
+
+        if (isVerified) {
+            String loginId = ownerService.findLoginIdByPhone(dto.getPhone())
+                    .map(LoginIdDTO::getLoginId) // LoginIdDTO 객체에서 loginId필드값 추출
+                    .orElse("로그인 ID를 찾을 수 없습니다.");
+            return ApiResponse.onSuccess(loginId);
+        } else {
+            return ApiResponse.onFailure("400", "인증번호가 일치하지 않습니다.", null);
+        }
     }
 }

--- a/src/main/java/coumo/server/web/controller/OwnerRestController.java
+++ b/src/main/java/coumo/server/web/controller/OwnerRestController.java
@@ -49,4 +49,20 @@ public class OwnerRestController {
 
     }
 
+    @PostMapping("/join/check-login-id")
+    @Operation(summary = "WEB 로그인 ID 중복 확인 API",
+            description = "WEB 로그인 ID 중복 확인 API 구현")
+    public ApiResponse<OwnerResponseDTO.CheckLoginIdResponseDTO> checkLoginId(@RequestBody @Valid OwnerRequestDTO.CheckLoginIdDTO request){
+        boolean isLoginIdAvailable = ownerService.isLoginIdAvailable(request.getLoginId());
+
+        if(isLoginIdAvailable){
+            // 로그인 ID가 사용 가능할 경우
+            return ApiResponse.onSuccess(OwnerResponseDTO.CheckLoginIdResponseDTO.builder()
+                    .loginId(request.getLoginId())
+                    .build());
+        } else {
+            // 로그인 ID가 이미 사용 중인 경우
+            return ApiResponse.onFailure("400", "이미 사용 중인 로그인 ID입니다.", null);
+        }
+    }
 }

--- a/src/main/java/coumo/server/web/controller/OwnerRestController.java
+++ b/src/main/java/coumo/server/web/controller/OwnerRestController.java
@@ -8,12 +8,11 @@ import coumo.server.service.owner.OwnerService;
 import coumo.server.web.dto.OwnerRequestDTO;
 import coumo.server.web.dto.OwnerResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -64,5 +63,16 @@ public class OwnerRestController {
             // 로그인 ID가 이미 사용 중인 경우
             return ApiResponse.onFailure("400", "이미 사용 중인 로그인 ID입니다.", null);
         }
+    }
+
+    @GetMapping("/mypage/{ownerId}/profile")
+    @Operation(summary = "마이페이지 내 프로필 조회 API", description = "로그인한 사장님의 마이페이지 프로필을 조회합니다.")
+    @Parameters({
+            @Parameter(name = "ownerId", description = "ownerId, path variable 입니다!"),
+    })
+    public ApiResponse<OwnerResponseDTO.MyPageDTO> myPage(@PathVariable Long ownerId){
+        return ownerService.findOwner(ownerId)
+                .map(owner -> ApiResponse.onSuccess(OwnerConverter.toMyPageDTO(owner)))
+                .orElse(ApiResponse.onFailure("400", "사용자 정보를 찾을 수 없습니다.", null));
     }
 }

--- a/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
@@ -1,9 +1,12 @@
 package coumo.server.web.dto;
 
 import coumo.server.domain.enums.Gender;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 public class CustomerRequestDTO {
+
+    /* 회원가입(App) */
     @Getter
     public static class CustomerJoinDTO {
         String loginId;
@@ -15,9 +18,18 @@ public class CustomerRequestDTO {
         String phone;
     }
 
+    /* 로그인(App) */
     @Getter
     public static class CustomerLoginDTO{
         String loginId;
         String password;
+    }
+
+
+    /* 로그인 중복확인(App) */
+    @Getter
+    public static class CheckCustomerLoginIdDTO {
+        @NotBlank(message = "로그인 ID는 필수 입력 항목입니다.")
+        String loginId;
     }
 }

--- a/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
@@ -20,7 +20,7 @@ public class CustomerRequestDTO {
 
     /* 로그인(App) */
     @Getter
-    public static class CustomerLoginDTO{
+    public static class CustomerLoginDTO {
         String loginId;
         String password;
     }
@@ -32,4 +32,18 @@ public class CustomerRequestDTO {
         @NotBlank(message = "로그인 ID는 필수 입력 항목입니다.")
         String loginId;
     }
+
+    /* 아이디 찾기(App) */
+    @Getter
+    public static class VerificationRequest {
+        String name;
+        String phone;
+    }
+
+    @Getter
+    public static class VerificationCodeDTO{
+        String phone;
+        String verificationCode;
+    }
+
 }

--- a/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
+++ b/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
@@ -42,12 +42,21 @@ public class CustomerResponseDTO {
         LocalDateTime createdAt;
     }
 
+
+    //로그인
     @Builder
     @Getter
     @AllArgsConstructor
     public static class CustomerLoginResultDTO{
         Long customerId;
         private final String token;
+    }
+
+    //로그인 중복확인
+    @Builder
+    @Getter
+    public static class CheckCustomerLoginIdResponseDTO{
+        private String loginId;
     }
 }
 

--- a/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
+++ b/src/main/java/coumo/server/web/dto/CustomerResponseDTO.java
@@ -58,5 +58,17 @@ public class CustomerResponseDTO {
     public static class CheckCustomerLoginIdResponseDTO{
         private String loginId;
     }
+
+    //내 프로필 조회
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class CustomerMyPageDTO{
+        String name;
+        String birthday;
+        String gender;
+        String phone;
+    }
+
 }
 

--- a/src/main/java/coumo/server/web/dto/LoginIdDTO.java
+++ b/src/main/java/coumo/server/web/dto/LoginIdDTO.java
@@ -1,0 +1,12 @@
+package coumo.server.web.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginIdDTO {
+    private String loginId;
+
+    public LoginIdDTO(String loginId){
+        this.loginId = loginId;
+    }
+}

--- a/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
@@ -29,5 +29,17 @@ public class OwnerRequestDTO {
         String loginId;
     }
 
+    /* 아이디 찾기(WEB) */
+    @Getter
+    public static class OwnerVerificationRequest {
+        String name;
+        String phone;
+    }
+
+    @Getter
+    public static class OwnerVerificationCodeDTO{
+        String phone;
+        String verificationCode;
+    }
 
 }

--- a/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
@@ -1,6 +1,7 @@
 package coumo.server.web.dto;
 
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 public class OwnerRequestDTO {
@@ -14,9 +15,19 @@ public class OwnerRequestDTO {
         String phone;
     }
 
+    /* 로그인(Web) */
     @Getter
     public static class LoginDTO{
         String loginId;
         String password;
     }
+
+    /* 로그인 중복확인(Web) */
+    @Getter
+    public static class CheckLoginIdDTO {
+        @NotBlank(message = "로그인 ID는 필수 입력 항목입니다.")
+        String loginId;
+    }
+
+
 }

--- a/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
+++ b/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
@@ -27,4 +27,10 @@ public class OwnerResponseDTO {
         Long storeId;
         private final String token;
     }
+
+    @Builder
+    @Getter
+    public static class CheckLoginIdResponseDTO{
+        private String loginId;
+    }
 }

--- a/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
+++ b/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
@@ -33,4 +33,13 @@ public class OwnerResponseDTO {
     public static class CheckLoginIdResponseDTO{
         private String loginId;
     }
+
+    @Builder
+    @Getter
+    public static class MyPageDTO{
+        String name;
+        String loginId;
+        String email;
+        String phone;
+    }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       default_batch_fetch_size: 100
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
 spring:
   profiles:
     active:
-      - prod
+      - dev


### PR DESCRIPTION
# 📄 Work Description
- APP&WEB 아이디 중복확인 구현 완료
- APP&WEB 아이디 찾기(SMS 인증) 구현 완료
- APP&WEB 내 프로필 조회 구현 완료
- 일부 코드의 수정(아래의 To Reviewers 내용 확인 부탁드립니다!)

# ⚙️ ISSUE
- closed #47 
- closed #56 


# 📷 Screenshot
 - 아이디 중복확인
<img width="702" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/78e7acf4-95b8-4d17-812d-4f71429eb746">

 - 아이디 찾기 (1) 인증번호 전송 여부 확인
<img width="704" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/a0ac96a8-70e0-49f1-879f-135eca8d0e47">
<img width="496" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/d3c90a51-4bcc-49c0-8df8-ea62b3c91539">

 - 아이디 찾기 (2) 인증번호 검증 및 로그인ID 반환
<img width="699" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/4edaf14b-f3c1-4aa3-a579-4aa113a40a39">

 - 내프로필 조회
<img width="694" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/9ec033e2-3b9b-4fdf-8185-18ca24d9b773">

# 💬 To Reviewers
✅ 오류를 해결하기 위해 build.gradle에서 spring.doc의 버전을 최신으로 변경하였습니다.
✅ 인증번호 전송하기 위해 CoolSMS를 이용하였고 yml에 추가해야 하는 관계로 회의 때 추가로 이야기 한 후에 노션에 추가하겠습니다!
✅ Swagger에서 테스트는 모두 완료 되었으나 서버에 연동을 안해봐서 연동 후에 확인은 필요할 것 같습니다!