### PR TITLE
[Fix/#86] : 로그인, 인증번호 관련 코드 수정 WEB&APP

### DIFF
--- a/src/main/java/coumo/server/converter/CustomerConverter.java
+++ b/src/main/java/coumo/server/converter/CustomerConverter.java
@@ -2,6 +2,7 @@ package coumo.server.converter;
 
 import coumo.server.domain.Customer;
 import coumo.server.domain.enums.Gender;
+import coumo.server.domain.enums.State;
 import coumo.server.web.dto.CustomerRequestDTO;
 import coumo.server.web.dto.CustomerResponseDTO;
 
@@ -36,6 +37,7 @@ public class CustomerConverter {
                 .gender(request.getGender())
                 .email(request.getEmail())
                 .phone(request.getPhone())
+                .state(State.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/coumo/server/converter/OwnerConverter.java
+++ b/src/main/java/coumo/server/converter/OwnerConverter.java
@@ -1,6 +1,7 @@
 package coumo.server.converter;
 
 import coumo.server.domain.Owner;
+import coumo.server.domain.enums.State;
 import coumo.server.web.dto.OwnerRequestDTO;
 import coumo.server.web.dto.OwnerResponseDTO;
 
@@ -24,6 +25,10 @@ public class OwnerConverter {
                 .token(token)
                 .isWrite(iswrite)
                 .createdAt(owner.getCreatedAt())
+                .name(owner.getName())
+                .loginId(owner.getLoginId())
+                .email(owner.getEmail())
+                .phone(owner.getPhone())
                 .build();
     }
 
@@ -34,6 +39,7 @@ public class OwnerConverter {
                 .name(request.getName())
                 .email(request.getEmail())
                 .phone(request.getPhone())
+                .state(State.ACTIVE)
                 .build();
     }
 

--- a/src/main/java/coumo/server/web/controller/CustomerRestController.java
+++ b/src/main/java/coumo/server/web/controller/CustomerRestController.java
@@ -114,14 +114,14 @@ public class CustomerRestController {
 
     @PostMapping("/join/send-verification-code")
     @Operation(summary = "[회원가입] APP 인증번호 전송 API", description = "인증번호가 전송되었는지 확인합니다.")
-    public ApiResponse<String> joinSendVerificationCode(@RequestBody CustomerRequestDTO.VerificationRequest request){
+    public ApiResponse<String> joinSendVerificationCode(@RequestBody CustomerRequestDTO.CustomerVerificationRequest request){
         messageService.sendMessage(request.getPhone());
         return ApiResponse.onSuccess("인증번호가 전송되었습니다.");
     }
 
     @PostMapping("/join/verify-code")
     @Operation(summary = "[회원가입] APP 인증번호 검증 API", description = "인증번호가 일치하는지 확인합니다.")
-    public ApiResponse<CustomerVerificationSuccessResponse> joinVerifyCode(@RequestBody OwnerRequestDTO.OwnerVerificationCodeDTO dto) {
+    public ApiResponse<CustomerVerificationSuccessResponse> joinVerifyCode(@RequestBody CustomerRequestDTO.CustomerVerificationCodeDTO dto) {
         boolean isAPPVerified = verificationCodeStorage.verifyCode(dto.getPhone(), dto.getVerificationCode());
         if (isAPPVerified) {
             return ApiResponse.onSuccess(CustomerVerificationSuccessResponse.customerSuccessWithCode(dto.getVerificationCode()));

--- a/src/main/java/coumo/server/web/controller/OwnerRestController.java
+++ b/src/main/java/coumo/server/web/controller/OwnerRestController.java
@@ -83,20 +83,20 @@ public class OwnerRestController {
         }
     }
 
-    @GetMapping("/mypage/{ownerId}/profile")
-    @Operation(summary = "WEB 마이페이지 내 프로필 조회 API", description = "로그인한 사장님의 마이페이지 프로필을 조회합니다.")
-    @Parameters({
-            @Parameter(name = "ownerId", description = "ownerId, path variable 입니다!"),
-    })
-    public ApiResponse<OwnerResponseDTO.MyPageDTO> myPage(@PathVariable Long ownerId){
-        return ownerService.findOwner(ownerId)
-                .map(owner -> ApiResponse.onSuccess(OwnerConverter.toMyPageDTO(owner)))
-                .orElse(ApiResponse.onFailure("400", "사용자 정보를 찾을 수 없습니다.", null));
-    }
+//    @GetMapping("/mypage/{ownerId}/profile")
+//    @Operation(summary = "WEB 마이페이지 내 프로필 조회 API", description = "로그인한 사장님의 마이페이지 프로필을 조회합니다.")
+//    @Parameters({
+//            @Parameter(name = "ownerId", description = "ownerId, path variable 입니다!"),
+//    })
+//    public ApiResponse<OwnerResponseDTO.MyPageDTO> myPage(@PathVariable Long ownerId){
+//        return ownerService.findOwner(ownerId)
+//                .map(owner -> ApiResponse.onSuccess(OwnerConverter.toMyPageDTO(owner)))
+//                .orElse(ApiResponse.onFailure("400", "사용자 정보를 찾을 수 없습니다.", null));
+//    }
 
     @PostMapping("/find-id")
     @Operation(summary = "[아이디찾기] WEB 인증번호 전송 API", description = "인증번호가 전송되었는지 확인합니다.")
-    public ApiResponse<String> sendVerificationCode(@RequestBody OwnerRequestDTO.OwnerVerificationRequest request) {
+    public ApiResponse<String> sendVerificationCode(@RequestBody OwnerRequestDTO.OwnerLoginVerificationRequest request) {
         Optional<Owner> ownerOpt = ownerService.findOwnerByNameAndPhone(request.getName(), request.getPhone());
         if (ownerOpt.isPresent()) {
             messageService.sendMessage(request.getPhone());
@@ -108,7 +108,7 @@ public class OwnerRestController {
 
     @PostMapping("/verify-code")
     @Operation(summary = "[아이디찾기] WEB 인증번호 검증 및 로그인 ID 반환 API", description = "인증번호가 일치하는지 확인하고 loginId를 반환합니다.")
-    public ApiResponse<VerificationResponseDTO> verifyCode(@RequestBody OwnerRequestDTO.OwnerVerificationCodeDTO dto) {
+    public ApiResponse<VerificationResponseDTO> verifyCode(@RequestBody OwnerRequestDTO.OwnerLoginVerificationCodeDTO dto) {
         boolean isVerified = verificationCodeStorage.verifyCode(dto.getPhone(), dto.getVerificationCode());
 
         if (isVerified) {

--- a/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
@@ -46,4 +46,16 @@ public class CustomerRequestDTO {
         String verificationCode;
     }
 
+    /* 회원 가입 시 휴대폰 인증 */
+    @Getter
+    public static class CustomerVerificationRequest {
+        String name;
+        String phone;
+    }
+
+    @Getter
+    public static class CustomerVerificationCodeDTO{
+        String phone;
+        String verificationCode;
+    }
 }

--- a/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/OwnerRequestDTO.java
@@ -42,4 +42,15 @@ public class OwnerRequestDTO {
         String verificationCode;
     }
 
+    @Getter
+    public static class OwnerLoginVerificationRequest {
+        String name;
+        String phone;
+    }
+
+    @Getter
+    public static class OwnerLoginVerificationCodeDTO{
+        String phone;
+        String verificationCode;
+    }
 }

--- a/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
+++ b/src/main/java/coumo/server/web/dto/OwnerResponseDTO.java
@@ -28,6 +28,10 @@ public class OwnerResponseDTO {
         private final String token;
         boolean isWrite;
         LocalDateTime createdAt;
+        String name;
+        String loginId;
+        String email;
+        String phone;
     }
 
     @Builder


### PR DESCRIPTION
# 📄 Work Description
- 로그인 시 ownerId, storeId, token, 최초로그인 여부, 서비스 가입날짜, name, loginId, email, phone 반환하도록 수정 완료
- 마이페이지 - 내 프로필 조회 api 삭제 완료
- 아이디 찾기 - 인증번호 검증 API 오류 수정 완료
- 회원가입 시 Customer 및 Owner의 State값 ACTIVE 로 기본설정 완료

# ⚙️ ISSUE
- closed #86 


# 📷 Screenshot
 - 로그인 시 Response 값 수정
<img width="701" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/79fda044-b871-4cfb-bab8-65baf9349df3">

 - 아이디 찾기 - 인증번호 검증 API 오류 수정
<img width="702" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/cbb33e09-9b78-4b77-9859-fc13975b2519">

 - 회원가입 시 Customer 및 Owner의 State값 ACTIVE로 기본설정
<img width="1100" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/e5a6ab08-a9cd-4cd1-893a-15a7faf7aa4f">


# 💬 To Reviewers
✅ Swagger에서 테스트는 모두 완료 되었으나 서버에 연동을 안해봐서 연동 후에 확인은 필요할 것 같습니다!