### PR TITLE
[Feat/#95] 커스텀 쿠폰 UI 서비스 기능 구현 및 일부코드 수정 WEB

### DIFF
--- a/src/main/java/coumo/server/converter/DesignReceiptConverter.java
+++ b/src/main/java/coumo/server/converter/DesignReceiptConverter.java
@@ -1,0 +1,32 @@
+package coumo.server.converter;
+
+import coumo.server.domain.DesignReceipt;
+import coumo.server.domain.Owner;
+import coumo.server.web.dto.DesignReceiptRequestDTO;
+import coumo.server.web.dto.DesignReceiptResponseDTO;
+
+public class DesignReceiptConverter {
+    public static DesignReceipt fromDTO(DesignReceiptRequestDTO dto, Owner owner) {
+        return DesignReceipt.builder()
+                .owner(owner)
+                .storeName(dto.getStoreName())
+                .phone(dto.getPhone())
+                .email(dto.getEmail())
+                .storeType(dto.getStoreType())
+                .couponDescription(dto.getCouponDescription())
+                .build();
+    }
+
+    public static DesignReceiptResponseDTO toResponseDTO(DesignReceipt designReceipt){
+        return new DesignReceiptResponseDTO(
+                designReceipt.getId(),
+                designReceipt.getStoreName(),
+                designReceipt.getPhone(),
+                designReceipt.getEmail(),
+                designReceipt.getStoreType(),
+                designReceipt.getCouponDescription(),
+                designReceipt.getCreatedAt(),
+                designReceipt.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/coumo/server/domain/DesignReceipt.java
+++ b/src/main/java/coumo/server/domain/DesignReceipt.java
@@ -20,11 +20,11 @@ public class DesignReceipt extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "store_id")
-    private Store store; //매장 아이디
+    @JoinColumn(name = "owner_id")
+    private Owner owner; //사장님 고유 ID
 
     @Column(nullable = false, length = 50)
-    private String couponTitle; //쿠폰 제목
+    private String storeName; //쿠폰 제목
 
     @Column(nullable = false, length = 16)
     private String phone; //휴대폰
@@ -38,4 +38,8 @@ public class DesignReceipt extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(16)")
     private StoreType storeType; //매장 종류
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store; //매장 아이디
 }

--- a/src/main/java/coumo/server/domain/Owner.java
+++ b/src/main/java/coumo/server/domain/Owner.java
@@ -56,6 +56,9 @@ public class Owner extends BaseEntity {
     private List<OwnerCoupon> ownerCouponList = new ArrayList<>();
 
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
+    private List<DesignReceipt> designReceiptList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
     private List<SubscriptionReceipt> subscriptionReceiptList = new ArrayList<>();
 
     public void setStore(Store store) {

--- a/src/main/java/coumo/server/repository/DesignReceiptRepository.java
+++ b/src/main/java/coumo/server/repository/DesignReceiptRepository.java
@@ -1,0 +1,7 @@
+package coumo.server.repository;
+
+import coumo.server.domain.DesignReceipt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DesignReceiptRepository extends JpaRepository<DesignReceipt, Long> {
+}

--- a/src/main/java/coumo/server/repository/StoreRepository.java
+++ b/src/main/java/coumo/server/repository/StoreRepository.java
@@ -27,6 +27,8 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByIdWithOwner(@Param("storeId") Long storeId);
     Optional<Store> findByOwner(Owner owner);
 
+    Optional<Store> findByName(String name);
+
     @Query(value = "SELECT s.* FROM store AS s " +
             "WHERE MBRContains(ST_GeomFromText(CONCAT('LINESTRING(', ?1, ' ', ?2, ', ', ?3, ' ', ?4, ')'), 4326), s.point) AND s.store_type <> 'NONE'",
             countQuery = "SELECT s.* FROM store AS s " +

--- a/src/main/java/coumo/server/service/design/DesignReceiptService.java
+++ b/src/main/java/coumo/server/service/design/DesignReceiptService.java
@@ -1,0 +1,8 @@
+package coumo.server.service.design;
+
+import coumo.server.domain.DesignReceipt;
+import coumo.server.web.dto.DesignReceiptRequestDTO;
+
+public interface DesignReceiptService {
+    DesignReceipt createDesignReceipt(DesignReceipt designReceipt);
+}

--- a/src/main/java/coumo/server/service/design/DesignReceiptServiceImpl.java
+++ b/src/main/java/coumo/server/service/design/DesignReceiptServiceImpl.java
@@ -1,0 +1,23 @@
+package coumo.server.service.design;
+
+import coumo.server.converter.DesignReceiptConverter;
+import coumo.server.domain.DesignReceipt;
+import coumo.server.domain.Owner;
+import coumo.server.repository.DesignReceiptRepository;
+import coumo.server.web.dto.DesignReceiptRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DesignReceiptServiceImpl implements DesignReceiptService {
+
+    private final DesignReceiptRepository designReceiptRepository;
+
+    @Override
+    public DesignReceipt createDesignReceipt(DesignReceipt designReceipt) {
+        return designReceiptRepository.save(designReceipt);
+    }
+}

--- a/src/main/java/coumo/server/web/controller/CouponController.java
+++ b/src/main/java/coumo/server/web/controller/CouponController.java
@@ -1,19 +1,16 @@
 package coumo.server.web.controller;
 
 import coumo.server.apiPayload.ApiResponse;
-import coumo.server.domain.DesignReceipt;
 import coumo.server.domain.Owner;
 import coumo.server.domain.OwnerCoupon;
 import coumo.server.domain.mapping.CustomerStore;
 import coumo.server.service.coupon.CouponService;
 import coumo.server.service.coupon.CustomerStoreService;
 import coumo.server.service.coupon.OwnerCouponService;
-import coumo.server.service.design.DesignReceiptService;
 import coumo.server.service.owner.OwnerService;
 import coumo.server.validation.annotation.ExistOwner;
 import coumo.server.web.dto.CouponRequestDTO;
 import coumo.server.web.dto.CouponResponseDTO;
-import coumo.server.web.dto.DesignReceiptRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/src/main/java/coumo/server/web/controller/CouponController.java
+++ b/src/main/java/coumo/server/web/controller/CouponController.java
@@ -1,16 +1,19 @@
 package coumo.server.web.controller;
 
 import coumo.server.apiPayload.ApiResponse;
+import coumo.server.domain.DesignReceipt;
 import coumo.server.domain.Owner;
 import coumo.server.domain.OwnerCoupon;
 import coumo.server.domain.mapping.CustomerStore;
 import coumo.server.service.coupon.CouponService;
 import coumo.server.service.coupon.CustomerStoreService;
 import coumo.server.service.coupon.OwnerCouponService;
+import coumo.server.service.design.DesignReceiptService;
 import coumo.server.service.owner.OwnerService;
 import coumo.server.validation.annotation.ExistOwner;
 import coumo.server.web.dto.CouponRequestDTO;
 import coumo.server.web.dto.CouponResponseDTO;
+import coumo.server.web.dto.DesignReceiptRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;

--- a/src/main/java/coumo/server/web/controller/CustomerRestController.java
+++ b/src/main/java/coumo/server/web/controller/CustomerRestController.java
@@ -180,15 +180,26 @@ public class CustomerRestController {
         }
     }
 
-    @PatchMapping("/reset-password/verify-code")
-    @Operation(summary = "[비밀번호찾기] APP 인증번호 검증 및 비밀번호 재설정 API", description = "코드 검증 및 비밀번호 재설정")
-    public ApiResponse<String> verifyCodeAndResetPassword(@RequestBody CustomerRequestDTO.CustomerPasswordResetVerifyCodeDTO dto) {
+    @PostMapping("/reset-password/verify-code")
+    @Operation(summary = "[비밀번호찾기] APP 인증번호 검증 API", description = "코드 검증")
+    public ApiResponse<VerificationAppPwSuccessResponse> verifyCodePasswordApp(@RequestBody CustomerRequestDTO.CustomerPasswordVerifyCodeDTO dto) {
         boolean isVerified = verificationCodeStorage.verifyCode(dto.getPhone(), dto.getVerificationCode());
         if (isVerified) {
+            return ApiResponse.onSuccess(VerificationAppPwSuccessResponse.successWithCode("인증번호 검증에 성공했습니다.", dto.getVerificationCode()));
+        } else {
+            return ApiResponse.onFailure("400", "인증번호가 일치하지 않습니다.", null);
+        }
+    }
+
+    @PatchMapping("/reset-password/set-pw")
+    @Operation(summary = "[비밀번호찾기] APP 비밀번호 재설정 API", description = "비밀번호 재설정")
+    public ApiResponse<String> verifyCodeAndResetPassword(@RequestBody CustomerRequestDTO.CustomerPasswordResetDTO dto) {
+        Customer customer = customerService.findByLoginId(dto.getLoginId());
+        if (customer != null) {
             customerService.resetPassword(dto.getLoginId(), dto.getNewPassword());
             return ApiResponse.onSuccess("비밀번호가 성공적으로 재설정되었습니다.");
         } else {
-            return ApiResponse.onFailure("400", "인증번호가 일치하지 않습니다.", null);
+            return ApiResponse.onFailure("404", "해당 사용자를 찾을 수 없습니다.", null);
         }
     }
 }

--- a/src/main/java/coumo/server/web/controller/DesignReceiptController.java
+++ b/src/main/java/coumo/server/web/controller/DesignReceiptController.java
@@ -1,0 +1,34 @@
+package coumo.server.web.controller;
+
+import coumo.server.apiPayload.ApiResponse;
+import coumo.server.converter.DesignReceiptConverter;
+import coumo.server.domain.DesignReceipt;
+import coumo.server.service.design.DesignReceiptService;
+import coumo.server.service.owner.OwnerService;
+import coumo.server.web.dto.DesignReceiptRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/coupon")
+public class DesignReceiptController {
+
+    private final OwnerService ownerService;
+    private final DesignReceiptService designReceiptService;
+
+    @PostMapping("/{ownerId}/coupon-ui-service")
+    @Operation(summary = "쿠폰 UI 서비스 구매하기")
+    @Parameters({@Parameter(name = "ownerId", description = "ownerId, path variable 입니다!"),
+    })
+    public ApiResponse<?> purchaseCouponUIService(@PathVariable Long ownerId, @RequestBody DesignReceiptRequestDTO requestDTO) {
+        return ownerService.findOwner(ownerId).map(owner -> {
+            DesignReceipt designReceipt = DesignReceiptConverter.fromDTO(requestDTO, owner);
+            DesignReceipt savedReceipt = designReceiptService.createDesignReceipt(designReceipt);
+            return ApiResponse.onSuccess(DesignReceiptConverter.toResponseDTO(savedReceipt));
+        }).orElseGet(() -> ApiResponse.onFailure("404", "사용자를 찾을 수 없습니다.",null));
+    }
+}

--- a/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/CustomerRequestDTO.java
@@ -66,10 +66,15 @@ public class CustomerRequestDTO {
     }
 
     @Getter
-    public static class CustomerPasswordResetVerifyCodeDTO{
+    public static class CustomerPasswordVerifyCodeDTO {
         String loginId;
         String phone;
         String verificationCode;
+    }
+
+    @Getter
+    public static class CustomerPasswordResetDTO{
+        String loginId;
         String newPassword;
     }
 }

--- a/src/main/java/coumo/server/web/dto/DesignReceiptRequestDTO.java
+++ b/src/main/java/coumo/server/web/dto/DesignReceiptRequestDTO.java
@@ -1,0 +1,13 @@
+package coumo.server.web.dto;
+
+import coumo.server.domain.enums.StoreType;
+import lombok.Getter;
+
+@Getter
+public class DesignReceiptRequestDTO {
+    String storeName;
+    String phone;
+    String email;
+    StoreType storeType;
+    String couponDescription;
+}

--- a/src/main/java/coumo/server/web/dto/DesignReceiptResponseDTO.java
+++ b/src/main/java/coumo/server/web/dto/DesignReceiptResponseDTO.java
@@ -1,0 +1,25 @@
+package coumo.server.web.dto;
+
+import coumo.server.domain.enums.StoreType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DesignReceiptResponseDTO {
+    private Long receiptId;
+    private String storeName;
+    private String phone;
+    private String email;
+    private StoreType storeType;
+    private String couponDescription;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/coumo/server/web/dto/VerificationAppPwSuccessResponse.java
+++ b/src/main/java/coumo/server/web/dto/VerificationAppPwSuccessResponse.java
@@ -1,0 +1,18 @@
+package coumo.server.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerificationAppPwSuccessResponse {
+    private String message;
+    private String verificationCode;
+
+    public static VerificationAppPwSuccessResponse successWithCode(String message, String verificationCode){
+        return new VerificationAppPwSuccessResponse(message,verificationCode);
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- [WEB] 커스텀 쿠폰 UI 서비스 기능 구현
- [APP] 비밀번호찾기 - 휴대폰 인증번호 검증과 비밀번호 재설정 API 분리 완료
- 커스텀 쿠폰 신청내역을 Owner별로 보여주기 위해 Store 테이블에 Owner 테이블을 추가로 매핑했습니다.


# ⚙️ ISSUE
- closed #95 


# 📷 Screenshot
 - [WEB] 커스텀 쿠폰 UI 서비스 기능 구현
<img width="1397" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/0d4b1bf4-da6a-4279-bd4e-92d7843bdf2d">

<img width="1388" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/e42a5b1c-ae26-4aad-afac-ff8d9fea93bf">

- APP 비밀번호 찾기 - 휴대폰 인증번호 검증 API
<img width="1384" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/49df0b93-7a3a-4c3a-9cfb-3dd996bcaff7">


- APP 비밀번호 찾기 - 비밀번호 재설정 API
<img width="1383" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/58f117a3-3909-4673-a19c-2c775c5596e7">


- APP 기존 비밀번호로 로그인하면 오류발생. 
<img width="1385" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/77ce99e4-e394-487f-b7c9-73a61ad9d568">

- APP 재설정된 비밀번호로 로그인에 성공한 모습
<img width="1385" alt="image" src="https://github.com/UMC-5th-Coumo/server/assets/150939763/387af5f3-864b-4418-b91a-1eef72a7be06">


# 💬 To Reviewers
✅ Swagger에서 테스트는 모두 완료 되었으나 서버에 연동을 안해봐서 연동 후에 확인은 필요할 것 같습니다!