### PR TITLE
[Fix/#100] : 토큰 검증 추가

### DIFF
--- a/src/main/java/coumo/server/service/statistics/StatisticsService.java
+++ b/src/main/java/coumo/server/service/statistics/StatisticsService.java
@@ -10,9 +10,13 @@ import coumo.server.repository.CustomerStoreRepository;
 import coumo.server.repository.StatisticsRepository;
 import coumo.server.repository.StoreRepository;
 import coumo.server.repository.TimetableRepository;
+import coumo.server.service.owner.OwnerService;
+import coumo.server.util.TokenCheck;
+import coumo.server.web.dto.CustomOwnerDetails;
 import coumo.server.web.dto.CustomerResponseDTO;
 import coumo.server.web.dto.StatisticsResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +32,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class StatisticsService {
     private final StatisticsRepository statisticsRepository;
     private final CustomerStoreRepository customerStoreRepository;
@@ -39,6 +44,7 @@ public class StatisticsService {
      * @param storeId 매장 ID
      */
     public Map<String, Object> getAllCustomers(Long storeId) {
+
         List<Customer> customers = statisticsRepository.getAllCustomers(storeId);
         List<CustomerResponseDTO> customerList = this.createCustomerDtoList(customers, storeId);
 
@@ -376,4 +382,5 @@ public class StatisticsService {
 
         return result;
     }
+
 }

--- a/src/main/java/coumo/server/web/controller/StatisticsController.java
+++ b/src/main/java/coumo/server/web/controller/StatisticsController.java
@@ -2,11 +2,18 @@ package coumo.server.web.controller;
 
 import coumo.server.apiPayload.ApiResponse;
 import coumo.server.service.statistics.StatisticsService;
+import coumo.server.util.TokenCheck;
+import coumo.server.web.dto.CustomOwnerDetails;
 import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Around;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -14,28 +21,54 @@ import java.util.Map;
 @RequestMapping("/api/statistics")
 public class StatisticsController {
     private final StatisticsService statisticsService;
+    private final TokenCheck tokenCheck;
 
     @GetMapping("/{storeId}/customer")
     public ApiResponse<Map<String, Object>> getAllCustomers(@PathVariable Long storeId) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getAllCustomers(storeId));
     }
+
     @GetMapping("/{storeId}/customer/new")
     public ApiResponse<Map<String, Object>> getNewCustomers(@PathVariable Long storeId) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
         return ApiResponse.onSuccess(statisticsService.getNewCustomers(storeId));
     }
 
     @GetMapping("/{storeId}/customer/regular")
     public ApiResponse<Map<String, Object>> getRegularCustomers(@PathVariable Long storeId) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+        
         return ApiResponse.onSuccess(statisticsService.getRegularCustomers(storeId));
     }
 
     @GetMapping("/{storeId}/day")
     public ApiResponse<?> getDayStatistics(@PathVariable Long storeId) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getWeekStatistics(storeId));
     }
 
     @GetMapping("/{storeId}/time")
     public ApiResponse<?> getTimeStatistics(@PathVariable Long storeId) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getTimeStatistics(storeId));
     }
 
@@ -43,6 +76,11 @@ public class StatisticsController {
     public ApiResponse<?> getGenderRatio(@PathVariable Long storeId, @RequestParam(required = false) String period,
                                          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
                                          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getGenderRatio(storeId, period, startDate, endDate));
     }
 
@@ -50,21 +88,41 @@ public class StatisticsController {
     public ApiResponse<?> getAgeGroup(@PathVariable Long storeId, @RequestParam(required = false) String period,
                                          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
                                          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getAgeGroup(storeId, period, startDate, endDate));
     }
 
     @GetMapping("/{storeId}/month-statistics")
     public ApiResponse<?> getMonthStatistics(@PathVariable Long storeId, @RequestParam int year,@RequestParam int month) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getMonthStatistics(storeId, year, month));
     }
 
     @GetMapping("/{storeId}/month-age")
     public ApiResponse<?> getMonthAgeStatistics(@PathVariable Long storeId, @RequestParam int year,@RequestParam int month) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getMonthAgeGroup(storeId, year, month));
     }
 
     @GetMapping("/{storeId}/month-day")
     public ApiResponse<?> getMonthDayStatistics(@PathVariable Long storeId, @RequestParam int year, @RequestParam int month) {
+
+        if (!tokenCheck.isAvailableStoreId(storeId)) {
+            return ApiResponse.onSuccess(Collections.singletonMap("message", "해당 매장에 접근 권한이 없습니다."));
+        }
+
         return ApiResponse.onSuccess(statisticsService.getMonthDayGroup(storeId, year, month));
     }
 


### PR DESCRIPTION
# 📄 Work Description
- 토큰 검증 기능 코드를 이용해 모든 통계 조회 기능에 토큰 검증이 되도록 하였습니다.
- 따라서 모든 통계 조회 기능에는 헤더에 토큰을 넣어줘야 하며, 해당 매장을 소유한 owner의 id로 로그인을 해야만 해당 매장의 통계를 확인할 수 있습니다.

# ⚙️ ISSUE
- closed #100 

# 📷 Screenshot

(store id 44를 소유한 owner로 로그인하여 해당 토큰을 헤더에 넣었을 때)

1. store id가 44인 매장을 검색하고자 할 때  
(api/statistics/44/customer)
![image](https://github.com/UMC-5th-Coumo/server/assets/96732525/398ea828-cd17-4435-bc51-adccd3954acb)


2. 타 매장을 검색하고자 할 때 (ex. store id 1)
(api/statistics/1/customer)
![image](https://github.com/UMC-5th-Coumo/server/assets/96732525/52dc57ef-f6e1-47b4-8ce6-939524244782)


# 💬 To Reviewers
수정 사항 있다면 말씀해주세요!